### PR TITLE
Update quick_post button style and redirect

### DIFF
--- a/bitstream.css
+++ b/bitstream.css
@@ -330,8 +330,16 @@
 .bitstream-form .wp-block-button button {
     border-radius: 13px;
 }
+.bitstream-full-editor {
+    text-align: center;
+}
 .bitstream-full-editor .wp-block-button__link {
     background-color: var(--wp--preset--color--accent-2);
+    border-radius: 13px;
+    transition: background-color 0.2s ease;
+}
+.bitstream-full-editor .wp-block-button__link:hover {
+    background-color: var(--wp--preset--color--accent-1);
 }
 .bitstream-login-button {
     text-align: center;

--- a/bitstream.php
+++ b/bitstream.php
@@ -579,7 +579,7 @@ function bitstream_quick_post_shortcode() {
     echo '<p><label>Image<br><input type="file" name="bit_image" accept="image/*"></label></p>';
     echo '<div class="wp-block-button bitstream-post-button"><button type="submit" class="wp-block-button__link wp-element-button"><strong>Post Bit</strong></button></div>';
     echo '</form>';
-    echo '<div class="wp-block-button bitstream-full-editor" style="margin-top:13px;"><a class="wp-block-button__link wp-element-button" href="'.esc_url(admin_url('post-new.php?post_type=bit')).'"><strong>Open Full Editor</strong></a></div>';
+    echo '<div class="wp-block-button bitstream-full-editor" style="margin-top:13px;text-align:center;"><a class="wp-block-button__link wp-element-button" href="'.esc_url(admin_url('post-new.php?post_type=bit')).'"><strong>Open Full Editor</strong></a></div>';
     return ob_get_clean();
 }
 add_shortcode('bitstream_quick_post', 'bitstream_quick_post_shortcode');
@@ -623,7 +623,7 @@ function bitstream_handle_quick_post_submission() {
                     wp_update_post(['ID'=>$post_id,'post_content'=>$content]);
                 }
             }
-            wp_redirect(get_permalink($post_id));
+            wp_redirect(home_url('/bitstream/'));
             exit;
         }
     }


### PR DESCRIPTION
## Summary
- tweak Quick Post button style
- redirect Quick Post submissions back to the BitStream feed

## Testing
- `php -l bitstream.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f98285a40832b964ed8fc9f24952f